### PR TITLE
Define taskmaster and filer images in the chart

### DIFF
--- a/charts/tesk/templates/common/tesk-deployment.yaml
+++ b/charts/tesk/templates/common/tesk-deployment.yaml
@@ -17,8 +17,12 @@ spec:
       - name: tesk-api
         image: {{ .Values.tesk.image }}
         env:
+        - name: TESK_API_TASKMASTER_IMAGE_NAME
+          value: {{ .Values.tesk.taskmaster_image_name }}
         - name: TESK_API_TASKMASTER_IMAGE_VERSION
           value: {{ .Values.tesk.taskmaster_image_version }}
+        - name: TESK_API_TASKMASTER_FILER_IMAGE_NAME
+          value: {{ .Values.tesk.taskmaster_filer_image_name }}
         - name: TESK_API_TASKMASTER_FILER_IMAGE_VERSION
           value: {{ .Values.tesk.taskmaster_filer_image_version }}
         - name: TESK_API_K8S_NAMESPACE

--- a/charts/tesk/values.yaml
+++ b/charts/tesk/values.yaml
@@ -20,7 +20,9 @@ tesk:
     tes_api_base_path: /v1
     image: eu.gcr.io/tes-wes/tesk-api:v1.1
     port: 8080
+    taskmaster_image_name: eu.gcr.io/tes-wes/taskmaster
     taskmaster_image_version: v0.10.0
+    taskmaster_filer_image_name: eu.gcr.io/tes-wes/filer
     taskmaster_filer_image_version: v0.10.0
     debug: false
     executor_retries: 2


### PR DESCRIPTION
Provide the ability to define image names for taskmaster and filer in the Helm chart.