### PR TITLE
build: store images at Docker Hub instead of GCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For organisational reasons, this project is split into 3 repositories:
 - [tesk-api](https://github.com/elixir-cloud-aai/tesk-api): Contains the service that implements the TES API and translates tasks into kubernetes batch calls
 - [tesk-core](https://github.com/elixir-cloud-aai/tesk-core):  Contains the code that is launched as images into the kubernetes cluster by tesk-api.
 
-If the API is running on your cluster it will pull the images from our `gcr.io` repository automatically.
+If the API is running on your cluster it will pull the images from our `docker.io` repository automatically.
 
 `TESK` is designed with the goal to support any `Kubernetes` cluster, for its deployment please refer to the [deployment](documentation/deployment_new.md) page.
 

--- a/charts/tesk/values.yaml
+++ b/charts/tesk/values.yaml
@@ -18,11 +18,11 @@ tesk:
     #tes_api_base_path:
     # For backwards compatibility with TES 0.3 - old base bath
     tes_api_base_path: /v1
-    image: eu.gcr.io/tes-wes/tesk-api:v1.1
+    image: docker.io/elixircloud/tesk-api:1.1.0
     port: 8080
-    taskmaster_image_name: eu.gcr.io/tes-wes/taskmaster
+    taskmaster_image_name:  docker.io/elixircloud/tesk-core-taskmaster
     taskmaster_image_version: v0.10.0
-    taskmaster_filer_image_name: eu.gcr.io/tes-wes/filer
+    taskmaster_filer_image_name: docker.io/elixircloud/tesk-core-filer
     taskmaster_filer_image_version: v0.10.0
     debug: false
     executor_retries: 2


### PR DESCRIPTION
This change moves the default deployment from google cloud, now using  docker.io as main deployment source.