### PR TITLE
Remove dependency to clusterType

### DIFF
--- a/charts/tesk/templates/common/taskmaster-rbac.yaml
+++ b/charts/tesk/templates/common/taskmaster-rbac.yaml
@@ -3,20 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskmaster
-{{ if eq .Values.clusterType "openshift" }}
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: taskmaster-role-binding
-subjects:
-- kind: ServiceAccount
-  name: taskmaster
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-{{ else }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -34,6 +20,7 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  - configmaps
   verbs:
   - create
   - delete
@@ -46,7 +33,6 @@ rules:
   verbs:
   - get
   - list
-  - delete
 - apiGroups:
   - batch
   resources:
@@ -69,5 +55,3 @@ roleRef:
   kind: Role
   name: taskmaster
   apiGroup: rbac.authorization.k8s.io
-{{ end }}
-

--- a/charts/tesk/templates/openshift/oc-route.yaml
+++ b/charts/tesk/templates/openshift/oc-route.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.clusterType "openshift" }}
+{{ if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/charts/tesk/values.yaml
+++ b/charts/tesk/values.yaml
@@ -4,8 +4,6 @@
 
 # host_name: tes.tsi.ebi.ac.uk
 host_name: ""
-# There are two options here: "openshift" or "kubernetes"
-clusterType: kubernetes
 #
 #
 #


### PR DESCRIPTION
There are two main changes:

- `.Capabilities.APIVersions.Has` is used to detect Route, that only openshift has.
- The new Role has been tweaked to (1) allow config maps to be created and (2) logs can no longer be deleted, but I think it was not used.

It works in OpenShift. 