### PR TITLE
build: update Helm chart version & change pathType

### DIFF
--- a/charts/tesk/Chart.yaml
+++ b/charts/tesk/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tesk
 description: A TESK-EXILIR Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: dev

--- a/charts/tesk/templates/ingress/ingress-rules.yaml
+++ b/charts/tesk/templates/ingress/ingress-rules.yaml
@@ -20,7 +20,7 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.path }}
-        pathType: Exact
+        pathType: Prefix
         backend:
           service:
             name: tesk-api


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the Helm chart version to 0.1.1 and modify the ingress pathType from 'Exact' to 'Prefix' for improved path matching flexibility.

Enhancements:
- Change the pathType in the ingress rules from 'Exact' to 'Prefix' to allow for more flexible path matching.

<!-- Generated by sourcery-ai[bot]: end summary -->